### PR TITLE
feat(preferences): added user preference with set and get

### DIFF
--- a/app/Filter/UserPreferenceFilter.php
+++ b/app/Filter/UserPreferenceFilter.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace App\Filter;
+use Closure;
+
+class UserPreferenceFilter
+{
+    public function handle($query, Closure $next)
+    {
+        $user = auth()->user();
+
+        if ($user && $user->preferences) {
+            $preferences = $user->preferences;
+
+            $query->when($preferences->preferred_sources, function ($q) use ($preferences) {
+                $q->whereIn('source', $preferences->preferred_sources);
+            });
+
+            $query->when($preferences->preferred_categories, function ($q) use ($preferences) {
+                $q->whereIn('category', $preferences->preferred_categories);
+            });
+
+            $query->when($preferences->preferred_authors, function ($q) use ($preferences) {
+                $q->whereIn('author', $preferences->preferred_authors);
+            });
+        }
+
+        return $next($query);
+    }
+}

--- a/app/Http/Controllers/API/V1/PersonalizedFeedController.php
+++ b/app/Http/Controllers/API/V1/PersonalizedFeedController.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace App\Http\Controllers\API\V1;
+
+use App\Filter\CategoryFilter;
+use App\Filter\DateFilter;
+use App\Filter\KeywordFilter;
+use App\Filter\SourceFilter;
+use App\Filter\UserPreferenceFilter;
+use App\Http\Controllers\Controller;
+use App\Models\Article;
+use App\Traits\SendResponse;
+use Illuminate\Pipeline\Pipeline;
+
+class PersonalizedFeedController extends Controller
+{
+    use SendResponse;
+    public function __invoke()
+    {
+        $articles = app(Pipeline::class)
+            ->send(Article::query())
+            ->through([
+                UserPreferenceFilter::class, // Add this filter here
+            ])
+            ->thenReturn()
+            ->latest()
+            ->paginate(20);
+
+        return $this->success($articles, 'Articles retrieved successfully.');
+    }
+}

--- a/app/Http/Controllers/API/V1/UserPreferenceController.php
+++ b/app/Http/Controllers/API/V1/UserPreferenceController.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace App\Http\Controllers\API\V1;
+
+use App\Http\Controllers\Controller;
+use App\Http\Requests\UserPreferenceStoreRequest;
+use App\Traits\SendResponse;
+use Illuminate\Http\JsonResponse;
+use function auth;
+
+class UserPreferenceController extends Controller
+{
+    use SendResponse;
+
+    public function index(): JsonResponse
+    {
+        $preferences = auth()->user()->preferences;
+        return $this->success($preferences, 'User Preferences List');
+    }
+
+    public function store(UserPreferenceStoreRequest $request): JsonResponse
+    {
+        $preferences = auth()->user()->preferences()->updateOrCreate(
+            ['user_id' => auth()->id()],
+            $request->validated()
+        );
+        return $this->success($preferences, 'User Preferences Updated');
+    }
+}

--- a/app/Http/Requests/UserPreferenceStoreRequest.php
+++ b/app/Http/Requests/UserPreferenceStoreRequest.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class UserPreferenceStoreRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     */
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, \Illuminate\Contracts\Validation\ValidationRule|array<mixed>|string>
+     */
+    public function rules(): array
+    {
+        return [
+            'preferred_sources' => 'required|array',
+            'preferred_categories' => 'required|array',
+            'preferred_authors' => 'required|array',
+        ];
+    }
+}

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -4,6 +4,8 @@ namespace App\Models;
 
 // use Illuminate\Contracts\Auth\MustVerifyEmail;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Database\Eloquent\Relations\HasOne;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
 use Laravel\Sanctum\HasApiTokens;
@@ -45,5 +47,10 @@ class User extends Authenticatable
             'email_verified_at' => 'datetime',
             'password' => 'hashed',
         ];
+    }
+
+    public function preferences(): HasOne
+    {
+        return $this->hasOne(UserPreference::class);
     }
 }

--- a/app/Models/UserPreference.php
+++ b/app/Models/UserPreference.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class UserPreference extends Model
+{
+    protected $fillable = [
+        'user_id',
+        'preferred_sources',
+        'preferred_categories',
+        'preferred_authors',
+    ];
+
+    protected $casts = [
+        'preferred_sources' => 'array',
+        'preferred_categories' => 'array',
+        'preferred_authors' => 'array',
+    ];
+
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo(User::class);
+    }
+}

--- a/app/Services/GuardianNewsService.php
+++ b/app/Services/GuardianNewsService.php
@@ -9,6 +9,7 @@ use Exception;
 use Illuminate\Http\Client\ConnectionException;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Http;
+use function dd;
 
 class GuardianNewsService implements NewsSourceInterface
 {
@@ -56,7 +57,7 @@ class GuardianNewsService implements NewsSourceInterface
             if (!empty($article['fields']['body'])) {
                 $data[] = [
                     'title' => $article['webTitle'],
-                    'source' => $article['publication'],
+                    'source' => $article['fields']['publication'],
                     'published_at' => Carbon::parse($article['webPublicationDate'])->format('Y-m-d H:i:s'),
                     'content' => strip_tags($article['fields']['body']),
                     'author' => $article['fields']['byline'] ?? 'Unknown',

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Console\Commands\FetchArticlesCommand;
 use Illuminate\Foundation\Application;
 use Illuminate\Foundation\Configuration\Exceptions;
 use Illuminate\Foundation\Configuration\Middleware;
@@ -20,6 +21,11 @@ return Application::configure(basePath: dirname(__DIR__))
     ->withMiddleware(function (Middleware $middleware) {
         $middleware->statefulApi();
     })
+
     ->withExceptions(function (Exceptions $exceptions) {
         //
-    })->create();
+    })
+    ->withSchedule(function ($schedule) {
+        $schedule->command('fetch-articles')->daily();
+    })
+    ->create();

--- a/database/migrations/2024_11_18_102655_create_user_preferences_table.php
+++ b/database/migrations/2024_11_18_102655_create_user_preferences_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use App\Models\User;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('user_preferences', function (Blueprint $table) {
+            $table->id();
+            $table->foreignIdFor(User::class)->constrained()->cascadeOnDelete();
+            $table->json('preferred_sources')->nullable();
+            $table->json('preferred_categories')->nullable();
+            $table->json('preferred_authors')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('user_preferences');
+    }
+};

--- a/routes/api.php
+++ b/routes/api.php
@@ -4,7 +4,9 @@ use App\Http\Controllers\API\V1\ArticleController;
 use App\Http\Controllers\API\V1\Auth\LoginController;
 use App\Http\Controllers\API\V1\Auth\PasswordResetController;
 use App\Http\Controllers\API\V1\Auth\RegisterController;
+use App\Http\Controllers\API\V1\PersonalizedFeedController;
 use App\Http\Controllers\API\V1\ProfileController;
+use App\Http\Controllers\API\V1\UserPreferenceController;
 use Illuminate\Support\Facades\Route;
 
 
@@ -18,7 +20,13 @@ Route::group(['prefix' => 'auth'], function () {
 
 Route::group(['prefix' => 'users', 'middleware' => ['auth:sanctum']], function () {
     Route::get('/profile', [ProfileController::class, 'index']);
-    Route::post('logout', [ProfileController::class, 'destroy']);
+    Route::post('/logout', [ProfileController::class, 'destroy']);
+
+    Route::get('/preferences', [UserPreferenceController::class, 'index']);
+    Route::post('/preferences', [UserPreferenceController::class, 'store']);
+
+    Route::get('personalized-feed', PersonalizedFeedController::class);
+
 });
 
 Route::get('/articles', [ArticleController::class, 'index']);

--- a/routes/console.php
+++ b/routes/console.php
@@ -3,6 +3,3 @@
 use Illuminate\Foundation\Inspiring;
 use Illuminate\Support\Facades\Artisan;
 
-Artisan::command('inspire', function () {
-    $this->comment(Inspiring::quote());
-})->purpose('Display an inspiring quote')->hourly();


### PR DESCRIPTION


## Release Notes

- **New Features**
	- Introduced user preference management, allowing users to set and retrieve their article preferences.
	- Added a personalized feed endpoint to deliver customized content based on user preferences.

- **Bug Fixes**
	- Standardized logout route definition for consistency.

- **Chores**
	- Implemented daily scheduling for fetching articles.

- **Database**
	- Created a new `user_preferences` table to store user-specific preferences.


## Walkthrough
This pull request introduces several new features and modifications to the application, focusing on user preferences and personalized content delivery. It adds a `UserPreferenceFilter` to apply user-specific filters to queries, a `PersonalizedFeedController` for handling personalized feeds, and a `UserPreferenceController` for managing user preferences. Additionally, a `UserPreferenceStoreRequest` is created for validating user preference data. The `User` model is updated to include a relationship with user preferences, and a migration is added to create the `user_preferences` table. The API routes are also updated to accommodate these new functionalities.

## Changes

| File | Change Summary |
|------|----------------|
| `app/Filter/UserPreferenceFilter.php` | Added `UserPreferenceFilter` class with `handle($query, Closure $next)` method for applying user-specific filters. |
| `app/Http/Controllers/API/V1/PersonalizedFeedController.php` | Added `PersonalizedFeedController` class with `__invoke()` method for handling personalized feeds using the Laravel Pipeline. |
| `app/Http/Controllers/API/V1/UserPreferenceController.php` | Added `UserPreferenceController` class with `index()` and `store(UserPreferenceStoreRequest $request)` methods for managing user preferences. |
| `app/Http/Requests/UserPreferenceStoreRequest.php` | Added `UserPreferenceStoreRequest` class with `authorize()` and `rules()` methods for validating user preference data. |
| `app/Models/User.php` | Added `preferences()` method to establish a one-to-one relationship with the `UserPreference` model. |
| `app/Models/UserPreference.php` | Added `UserPreference` class with `$fillable` and `$casts` properties, and `user()` method for `BelongsTo` relationship with `User`. |
| `app/Services/GuardianNewsService.php` | Modified `storeArticles` method to update the source of the article's publication information. |
| `bootstrap/app.php` | Added scheduling for `fetch-articles` command to run daily. |
| `database/migrations/2024_11_18_102655_create_user_preferences_table.php` | Added migration for creating `user_preferences` table with necessary columns and constraints. |
| `routes/api.php` | Updated routes to include `PersonalizedFeedController` and `UserPreferenceController`, added new routes for user preferences and personalized feeds, and standardized logout route path. |
| `routes/console.php` | Removed `inspire` command registration from Artisan console. |